### PR TITLE
feat & fix: 添加和修复一些功能

### DIFF
--- a/BehaviourPack/scripts/Main.js
+++ b/BehaviourPack/scripts/Main.js
@@ -437,7 +437,7 @@ system_ids.tag = system.runInterval(() => {
 
 var follow_index = 0;
 system_ids.follow = system.runInterval(() => {
-  follow_index = (follow_index + 1) % 15;
+  follow_index = (follow_index + 1) % 37;
   const shouldTeleport = follow_index === 0;
 
   const players = world.getAllPlayers();
@@ -502,9 +502,21 @@ system_ids.follow = system.runInterval(() => {
           easeOptions: cameraEaseOptions
         });
         break;
+      
+      case 2: {
+        if (shouldTeleport && player.dimension.id !== targetDimension.id) { // 同步维度
+          player.runCommand(`titleraw "${player.name}" actionbar {"rawtext":[{"text":"同步 ${targetPlayer.name} 维度 : ${targetDimension.id.replace(/^minecraft:/, "")}"}]}`);
+          player.runCommand(`execute in ${targetDimension.id.replace(/^minecraft:/, "")} run tp @s ~ ~ ~`);
+        }
+
+        world.getDimension("minecraft:overworld").runCommand(`execute as "${targetPlayer.name}" at @s run camera "${player.name}" set minecraft:free ease 0.5 linear pos ^1.1 ^1.6 ^-2.2 rot ~ ~10`);
+        const headLoc = targetPlayer.getHeadLocation()
+        player.onScreenDisplay.setActionBar(`§b视监 ${targetPlayer.name} 中...§r\n§l§aX§r:§a${~~headLoc.x}§r, §l§bY§r:§b${~~headLoc.y}§r, §l§eZ§r:§e${~~headLoc.z}§r`)
+        break;
+      }
     }
   }
-}, 5);
+}, 2);
 
 system_ids.second = system.runInterval(() => {
   const players = world.getAllPlayers();
@@ -7467,7 +7479,7 @@ function followBar(player) {
   }
   ui.title = "跟踪视角"
   ui.options("index", text + "\n选择玩家", names, 0)
-  ui.options("mode", "选择跟踪模式", ["第一视角", "自由视角"], 0)
+  ui.options("mode", "选择跟踪模式", ["第一视角", "自由视角", "越肩视角"], 0)
   ui.show(player, (r) => {
     player.camera.fade({
       fadeColor: {
@@ -7485,7 +7497,7 @@ function followBar(player) {
       var lo = players[r.index].location
       if (r.mode === 0) {
         tp_entity(player, players[r.index].dimension, lo.x, -10000, lo.z, false)
-      } else {
+      } else if (r.mode === 1) {
         tp_entity(player, players[r.index].dimension, lo.x, -10000 + lo.y, lo.z, false)
       }
 

--- a/BehaviourPack/scripts/Main.js
+++ b/BehaviourPack/scripts/Main.js
@@ -2159,10 +2159,33 @@ function chatBoardBar(player, block, creater) {
       text: get_text("board.clear"),
       icon: ui_icon.rubbish,
       func: () => {
-        const emptyContent = [];
+        /*const emptyContent = [];
         save_data("content", to_json(emptyContent), item);
         container.setItem(0, item);
-        chatBoardBar(player, block, creater);
+        chatBoardBar(player, block, creater);*/
+        // 添加确认对话框
+        var confirmUI = new btnBar()
+        confirmUI.title = "确认清理"
+        confirmUI.body = ["确定要清空所有留言吗？", "此操作不可恢复！"]
+
+        confirmUI.btns = [{
+          text: "确认清空",
+          icon: ui_icon.delete,
+          func: () => {
+            const emptyContent = []
+            save_data("content", to_json(emptyContent), item)
+            container.setItem(0, item)
+            chatBoardBar(player, block, creater)
+          }
+        }, {
+          text: "取消",
+          icon: ui_icon.back,
+          func: () => {
+            chatBoardBar(player, block, creater)  // 返回留言板
+          }
+        }]
+
+        confirmUI.show(player)
       }
     });
   }

--- a/BehaviourPack/scripts/Main.js
+++ b/BehaviourPack/scripts/Main.js
@@ -4126,7 +4126,7 @@ function get_pos_name(pos) {
   return `[${get_di(pos.di).name}]${pos.name}`
 }
 
-function editPosBar(player, pos, save = function () { }, back = function () { }) {
+/*function editPosBar(player, pos, save = function () { }, back = function () { }) {
   var ui = new infoBar()
   var poss = [null, null]
   var texts = ["保持位置", "当前位置"]
@@ -4171,6 +4171,76 @@ function editPosBar(player, pos, save = function () { }, back = function () { })
     switch (r.lo) {
       case 0:
 
+        break
+      case 1:
+        pos.x = player.location.x
+        pos.y = player.location.y
+        pos.z = player.location.z
+        pos.di = player.dimension.id
+        break
+      default:
+        pos.x = poss[r.lo].x
+        pos.y = poss[r.lo].y
+        pos.z = poss[r.lo].z
+        break
+    }
+
+    save()
+    var ui2 = new btnBar()
+    viewPosBar(player, pos, true, ui2, save, back)
+  })
+}*/
+function editPosBar(player, pos, save = function () { }, back = function () { }) {
+  var ui = new infoBar()
+  var poss = [null, null]
+  var texts = ["保持位置", "当前位置"]
+  ui.cancel = () => {
+    back()
+  }
+
+  if (Object.keys(pos).length === 0) {
+    object_override(pos, {
+      "owner": get_id(player),
+      "di": player.dimension.id,
+      "x": player.location.x,
+      "y": player.location.y,
+      "z": player.location.z,
+      "name": "",
+      "icon": null,
+      "home": false,
+    })
+    texts = ["当前位置", "当前位置"]
+    ui.cancel = () => {
+      pos.name = undefined
+      save()
+      back()
+    }
+  }
+
+  for (var p of get_player_personal_pos()) {
+    poss.push(p)
+    texts.push(get_pos_name(p))
+  }
+
+  ui.title = "编辑传送点"
+  ui.input("name", "传送点名称", "输入名称", pos.name)
+  add_pictures_choice(ui, "选择传送点图标", pos.icon)
+  ui.options("lo", "位置", texts, 0)
+  ui.toggle("home", "设为Home(仅个人传送点有效)", pos.home)
+
+  ui.show(player, (r) => {
+    // 重名检测（仅对公共传送点）
+    if (world_pos.includes(pos) && world_pos.some(p => p !== pos && p.name === r.name)) {
+      player.sendMessage("§c已存在同名的公共传送点！");
+      editPosBar(player, pos, save, back); // 重新打开编辑界面
+      return;
+    }
+
+    pos.name = r.name
+    pos.icon = r.icon
+    pos.home = r.home
+    switch (r.lo) {
+      case 0:
         break
       case 1:
         pos.x = player.location.x
@@ -4237,9 +4307,17 @@ function viewPosBar(player, pos, editable, ui = new btnBar(), save = function ()
       text: "删除",
       icon: ui_icon.delete,
       func: () => {
-        delete pos.name
-        save()
-        back()
+        confirm(player, `确认删除传送点"${pos.name}"吗？`, (result) => {
+          if (result) {
+            delete pos.name
+            save()
+            back()
+          } else {
+            // 不删除，重新打开当前界面
+            //viewPosBar(player, pos, editable)//, ui, save, back)
+            back()
+          }
+        })
       }
     }
     ])

--- a/BehaviourPack/scripts/Main.js
+++ b/BehaviourPack/scripts/Main.js
@@ -2078,6 +2078,7 @@ function acceptTPA(player) {
     }
 
     chat("§e[传送系统]正在进行玩家传送", [player, goal]);
+    delete goal.tpa;
   } else {
     chat(get_text("tp.fail"), [player]);
   }

--- a/BehaviourPack/scripts/Main.js
+++ b/BehaviourPack/scripts/Main.js
@@ -4272,10 +4272,10 @@ function viewPosBar(player, pos, editable, ui = new btnBar(), save = function ()
     back()
   }
   ui.body = [
-    "传送点:" + pos.name,
-    `创建者:${get_name_by_id(pos.owner)}`,
-    `维度:${get_di(pos.di).name}`,
-    `坐标:${pos_to_text(pos)}`
+    "§b传送点§r: " + pos.name,
+    `§b创建者§r: ${get_name_by_id(pos.owner)}`,
+    `§a所在维度§r: ${get_di(pos.di).name}`,
+    `§a所在坐标§r: ${pos_to_text(pos)}`
   ]
 
   ui.btns = [{
@@ -4501,31 +4501,64 @@ function groupPosBar(player) {
   ui.show(player)
 }
 
-function worldPosBar(player) {
+
+function worldPosBar(player, page = 0, reverseOrder = false) {
+  const PAGE_SIZE = 50;
+  const MAX_POINTS = 200;
+
+  // 根据参数决定是否倒序
+  const displayPos = reverseOrder ? [...world_pos].reverse() : world_pos;
+
+  const startIdx = page * PAGE_SIZE;
+  const endIdx = Math.min(startIdx + PAGE_SIZE, displayPos.length);
+  const totalPages = Math.max(1, Math.ceil(displayPos.length / PAGE_SIZE));
+
   var ui = new btnBar()
-  ui.title = "世界公共点"
-  ui.body = "管理世界的传送点"
-  for (var pos of world_pos) {
+  ui.title = `世界公共点 (${page + 1}/${totalPages}页) - ${reverseOrder ? "倒序" : "正序"}`
+
+  ui.body = `添加传送点时记得加上图标哦∽\n§b总共记录 §a(${world_pos.length}/${MAX_POINTS})§b 个传送点`
+
+  // 遍历显示数组
+  for (var i = startIdx; i < endIdx; i++) {
+    const pos = displayPos[i];
     ui.btns.push({
       text: `[${get_di(pos.di).name}]${pos.name}`,
       icon: pictures[pos.icon],
-      op: {
-        "pos": pos
-      },
+      op: { "pos": pos },
       func: (op) => {
         var ui2 = new btnBar()
         ui2.cancel = () => {
-          worldPosBar(player)
+          worldPosBar(player, page, reverseOrder)
         }
         viewPosBar(player, op.pos, (get_id(player) === op.pos.owner || get_op_level(player) > 0), ui2, () => {
           save_world_pos()
         }, () => {
-          worldPosBar(player)
+          worldPosBar(player, page, reverseOrder)
         })
       }
     })
   }
-  if (world_pos.length < 100) {
+
+  // 添加排序切换按钮（放在最前面）
+  ui.btns.unshift({
+    text: reverseOrder ? "↓ 切换正序" : "↑ 切换倒序",
+    icon: reverseOrder ? "textures/ui/refresh_light" : "textures/ui/refresh",
+    func: () => {
+      worldPosBar(player, 0, !reverseOrder)  // 切换到相反排序，回到第1页
+    }
+  })
+
+  // 添加上一页按钮
+  if (page > 0) {
+    ui.btns.push({
+      text: "上一页",
+      icon: "textures/ui/arrow_dark_left_stretch",
+      func: () => worldPosBar(player, page - 1, reverseOrder)
+    })
+  }
+
+  // 添加传送点按钮
+  if (world_pos.length < MAX_POINTS) {
     ui.btns.push({
       text: "添加传送点",
       icon: ui_icon.add,
@@ -4533,16 +4566,29 @@ function worldPosBar(player) {
         world_pos.push({})
         editPosBar(player, (world_pos[world_pos.length - 1]), () => {
           save_world_pos()
+          // 添加后根据排序决定显示在第几页
+          const targetPage = reverseOrder ? 0 : Math.floor((world_pos.length - 1) / PAGE_SIZE)
+          worldPosBar(player, targetPage, reverseOrder)// 4726
         }, () => {
-          worldPosBar(player)
+          worldPosBar(player, page, reverseOrder)
         })
       }
+    })
+  }
+
+  // 添加下一页按钮
+  if (endIdx < displayPos.length) {
+    ui.btns.push({
+      text: "下一页",
+      icon: "textures/ui/arrow_dark_right",
+      func: () => worldPosBar(player, page + 1, reverseOrder)
     })
   }
 
   ui.show(player)
 }
 
+// 个人传送UI -调用者/被调用者-
 function personalPosBar(player, goal) {
   var ui = new btnBar()
   ui.title = "个人传送点"
@@ -4807,6 +4853,27 @@ function posBar(player) {
       func: () => {
         public_pos.push({})
         editPosBar(player, public_pos[public_pos.length - 1], () => {
+          save_public_pos()
+        }, () => {
+          posBar(player)
+        })
+      }
+    })
+  }
+
+  for (var pos of public_pos) {
+    ui.btns.push({
+      text: `${pos.name}`,
+      icon: pictures[pos.icon],
+      op: {
+        "pos": pos
+      },
+      func: (op) => {
+        var ui2 = new btnBar()
+        ui2.cancel = () => {
+          posBar(player)
+        }
+        viewPosBar(player, op.pos, is_public_editable(player), ui2, () => {
           save_public_pos()
         }, () => {
           posBar(player)


### PR DESCRIPTION
# 添加和修改公共传送点相关
添加了公共传送点设置排序的功能
添加了公共传送点的重名检测
添加了删除传送点的二次确认
<img width="1389" height="897" alt="Screenshot_20260511_234451_com mojang mcpeapollo_edit_1843035096472233" src="https://github.com/user-attachments/assets/6e2ca1f9-55c5-4dda-af49-911eab32a7d3" />

  
  
# 添加"越肩视角"视角跟踪功能项
如题，在管理菜单的视角跟踪项内添加了一个"越肩视角"项  
以便于更好的观察玩家  
<img width="1096" height="778" alt="Screenshot_20260511_234303_com mojang mcpeapollo_edit_1842152771870330" src="https://github.com/user-attachments/assets/96a8ce89-62f0-4c99-9951-21b0b5430adb" />

  
  
# 留言板清空确认
清空按钮很容易误触啊，所以就加了这个功能  
<img width="1356" height="651" alt="Screenshot_20260511_234430_com mojang mcpeapollo_edit_1842271497437680" src="https://github.com/user-attachments/assets/638fe03a-3f53-4ca6-abe6-2fe6cd46916d" />

  
  
# 修复玩家接受传送后请求队列未删除bug
玩家接受传送请求后，还可以再接受很多便  
本条就是修复了这个问题